### PR TITLE
node: Skip equal objects in LocalNodeStore.Update()

### DIFF
--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -209,15 +209,28 @@ func (s *LocalNodeStore) Get(ctx context.Context) (LocalNode, error) {
 // Update modifies the local node with a mutator. The updated value
 // is passed to observers. Calling LocalNodeStore.Get() from the
 // mutation function is forbidden, and would result in a deadlock.
+//
+// If the mutator produces no change (as determined by DeepEqual), the update
+// is skipped and observers are not woken up. This mirrors the upstream change
+// in cilium/cilium#41294 ("node: Skip equal objects in Update()") and avoids
+// redundant downstream work such as CiliumNode resource writes triggered by
+// no-op local node updates (which can be fatal during a Kubernetes apiserver
+// outage).
+//
+// NOTE: change detection relies on a shallow copy of the previous value, so
+// mutators must reassign fields rather than mutate referenced maps/slices in
+// place. All current callers follow this convention.
 func (s *LocalNodeStore) Update(update func(*LocalNode)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.getMu.Lock()
+	before := s.value
 	update(&s.value)
+	changed := !s.value.DeepEqual(&before)
 	s.getMu.Unlock()
 
-	if s.emit != nil {
+	if changed && s.emit != nil {
 		s.emit(s.value)
 	}
 }


### PR DESCRIPTION
Don't emit (and wake up observers) when a mutator produces no change to the local node. This prevents redundant downstream work -- most importantly the nodediscovery CiliumNode resource writes that are triggered on every local node emission. During a Kubernetes apiserver outage those writes fail and the retry path ends in logging.Fatal, crashing the agent. Skipping no-op updates keeps the agent from re-arming that fatal path when nothing actually changed.

This is a backport of the dedup behavior from upstream's StateDB-based LocalNodeStore, adapted to the 1.18 stream-based store.

Upstream-reference: https://github.com/cilium/cilium/pull/41294

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
